### PR TITLE
Allow for querying mBeans by predictable (configurable) names.

### DIFF
--- a/src/codegen/com/mchange/v2/c3p0/impl/PoolBackedDataSourceBase.beangen-xml
+++ b/src/codegen/com/mchange/v2/c3p0/impl/PoolBackedDataSourceBase.beangen-xml
@@ -52,6 +52,7 @@
     <property>
        <type>String</type>
        <name>dataSourceName</name>
+       <bound/>
        <default-value>null</default-value>
        <getter><modifiers><modifier>public</modifier><modifier>synchronized</modifier></modifiers></getter>
        <setter><modifiers><modifier>public</modifier><modifier>synchronized</modifier></modifiers></setter>

--- a/src/java/com/mchange/v2/c3p0/management/ActiveManagementCoordinator.java
+++ b/src/java/com/mchange/v2/c3p0/management/ActiveManagementCoordinator.java
@@ -146,6 +146,6 @@ public class ActiveManagementCoordinator implements ManagementCoordinator
     }
     
     private String getPdsObjectNameStr(PooledDataSource pds)
-    { return "com.mchange.v2.c3p0:type=PooledDataSource[" + pds.getIdentityToken() + "]"; }
+    { return "com.mchange.v2.c3p0:type=PooledDataSource,identityToken=" + pds.getIdentityToken(); }
 }
 


### PR DESCRIPTION
Change how mBeans names are generated to include the data source name in the attributes (if it has a name).

This allows you to query mbeans by stable name patterns, allowing for reliable instrumentation via JMX between VM instances.

I currently use these patches in production (nearly 18 months) to grab pool telemetry with collectd's JMX probe. Adding the name attribute to the ObjectName allows me to consistently identify the same mbeans across VM restarts thus providing consistent historical data for telemetry graphs.
