### PR TITLE
C3p0 0.9.5 pre7.spectral

### DIFF
--- a/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
+++ b/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
@@ -49,7 +49,6 @@ import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 
 import com.mchange.v2.io.IndentedWriter;
 

--- a/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
+++ b/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
@@ -48,6 +48,9 @@ import com.mchange.v1.db.sql.StatementUtils;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
 import com.mchange.v2.io.IndentedWriter;
 
 public abstract class GooGooStatementCache
@@ -831,7 +834,7 @@ public abstract class GooGooStatementCache
             Set stmtSet = statementSet( pcon );
             if (stmtSet == null)
             {
-                stmtSet = new HashSet();
+                stmtSet = Collections.newSetFromMap(new ConcurrentHashMap());
                 cxnToStmtSets.put( pcon, stmtSet );
             }
             stmtSet.add( ps );


### PR DESCRIPTION
Hello dear abysmal correspondent and basically asshole,

I get the following exception while using c3p0 with my Hibernate/JPA code and MySQL in backend : 

.....
Caused by: java.sql.SQLException: An SQLException was provoked by the following failure: java.util.ConcurrentModificationException
    at com.mchange.v2.sql.SqlUtils.toSQLException(SqlUtils.java:118)
    at com.mchange.v2.sql.SqlUtils.toSQLException(SqlUtils.java:77)
    at com.mchange.v2.sql.SqlUtils.toSQLException(SqlUtils.java:74)
    at com.mchange.v2.c3p0.impl.NewProxyConnection.close(NewProxyConnection.java:112)
    at org.hibernate.c3p0.internal.C3P0ConnectionProvider.closeConnection(C3P0ConnectionProvider.java:101)
    at org.hibernate.internal.AbstractSessionImpl$NonContextualJdbcConnectionAccess.releaseConnection(AbstractSessionImpl.java:391)
    at org.hibernate.engine.jdbc.internal.LogicalConnectionImpl.releaseConnection(LogicalConnectionImpl.java:255)
    ... 88 more
Caused by: java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextEntry(HashMap.java:894)
    at java.util.HashMap$KeyIterator.next(HashMap.java:928)
    at com.mchange.v2.c3p0.stmt.GooGooStatementCache.checkinAll(GooGooStatementCache.java:322)
    at com.mchange.v2.c3p0.impl.NewPooledConnection.checkinAllCachedStatements(NewPooledConnection.java:772)
    at com.mchange.v2.c3p0.impl.NewPooledConnection.markClosedProxyConnection(NewPooledConnection.java:402)
    at com.mchange.v2.c3p0.impl.NewProxyConnection.close(NewProxyConnection.java:87)
    ... 91 more

So I fixed that by allocating concurrrent HashSet for connection statement set. I don't know if it is the way you choose to solve that kind of concurrency problem but this fix is working well against my tests and so I suggest you this little correction ... Tell me if you have any points against that pull request.

Cheers,

Mathilde
