### PR TITLE
Bug #133: guard protecting C3P0 from drivers not proxying statements correctly.

### DIFF
--- a/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
+++ b/src/java/com/mchange/v2/c3p0/stmt/GooGooStatementCache.java
@@ -609,6 +609,9 @@ public abstract class GooGooStatementCache
         boolean out;
         LinkedList q = checkoutQueue( key );
         out = q.remove( pstmt );
+        if (!out && Debug.DEBUG && !pstmt.equals(pstmt))
+            throw new RuntimeException("Driver bug: " +
+            "Your JDBC driver seems to proxy statement objects but fails handling equals() correctly as the object is not equal to itself!");
         if (q.isEmpty() && keySet( key ).isEmpty())
             keyToKeyRec.remove( key );
         return out;


### PR DESCRIPTION
At least the MySQL replication driver is affected, see http://sourceforge.net/p/c3p0/bugs/133/.

I filed a bug report to MySQL as http://bugs.mysql.com/bug.php?id=78313,
and suggested a fix of it as https://github.com/mysql/mysql-connector-j/pull/5.

However, other drivers such as PostgreSQL are affected as well. This must be fixed in the driver code and the guard aids people identifying the problem...

Best regards,
   Thomas.
