### PR TITLE
Ensure that force_kill_acquires is set to false

### DIFF
--- a/src/java/com/mchange/v2/resourcepool/BasicResourcePool.java
+++ b/src/java/com/mchange/v2/resourcepool/BasicResourcePool.java
@@ -960,10 +960,12 @@ class BasicResourcePool implements ResourcePool
                 otherWaiters.add( t );
                 this.wait();
             }
-            force_kill_acquires = false;
         }
         finally
-        { otherWaiters.remove( t ); }
+        {
+            force_kill_acquires = false;
+            otherWaiters.remove( t );
+        }
     }
 
     //same as close(), but we do not destroy checked out


### PR DESCRIPTION
We have seen this issue couple of time in production where `force_kills_acquires` fails to unset and gets stuck in a loop. This PR addresses issue #90 and is almost same as PR #91. I did not see any progress there hence this PR.