### PR TITLE
Remove AutoCloseable reference from PooledDataSource docs

### DIFF
--- a/src/doc/index.html
+++ b/src/doc/index.html
@@ -824,9 +824,7 @@ static void cleanup(DataSource ds) throws SQLException
       <p>
 	<a href="apidocs/com/mchange/v2/c3p0/ComboPooledDataSource.html"><tt>ComboPooledDataSource</tt></a>
 	is an instance of <a href="apidocs/com/mchange/v2/c3p0/PooledDataSource.html"><tt>PooledDataSource</tt></a>,
-	and can be closed directly via its <tt>close()</tt> method. <tt>PooledDataSource</tt> implements <tt>java.lang.AutoCloseable</tt>,
-	so they may be managed by 
-	<a href="http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">Java 7+ try-with-resources</a> blocks.
+	and can be closed directly via its <tt>close()</tt> method.
       </p>
       <p>
 	Unreferenced instances of <a href="apidocs/com/mchange/v2/c3p0/PooledDataSource.html"><tt>PooledDataSource</tt></a>


### PR DESCRIPTION
Fix #94.

The feature was removed in f2950f5011f3a1ae51202c4c3a8b510c534265cb
to maintain Java 6 compatability.