### PR TITLE
update unreturnedConnectionTimeout description in documentation

### DIFF
--- a/src/doc/index.html
+++ b/src/doc/index.html
@@ -2697,8 +2697,9 @@ c3p0 {
 		pool. And that's a shame. Zero means no timeout, applications are expected to close() their own Connections.
 		Obviously, if a non-zero value is set, it should be to a value longer than any Connection should reasonably
 		be checked-out. Otherwise, the pool will occasionally kill Connections in active use, which is bad. 
-	    <b><i>This is basically a bad idea, but it's a commonly requested feature. Fix your $%!@% applications
-	    so they don't leak Connections! Use this temporarily in combination with 
+	    <b><i>An appropriate value will increase resiliency of the application when the appearance of a bug would start causing malfunctions.
+		  Appropriate monitoring is highly suggested to enable discovery and fixing of the applications so they don't leak Connections!
+		  Use this in temporary combination with 
 	    <tt>debugUnreturnedConnectionStackTraces</tt> to figure out
 	    where Connections are being checked-out that don't make it back into the pool!</i></b>
 	    [See <a href="#configuring_to_debug_and_workaround_broken_clients">"Configuring to Debug and Workaround Broken Client Applications"</a>]


### PR DESCRIPTION
This is an opinable proposal.

I'd like to not see this option being discouraged as I think it's necessary for increased resiliency in prod-ready applications.
Still, the description should continue to point out that these kind of errors must be monitored and fixed.